### PR TITLE
FIX Map sapphire to framework

### DIFF
--- a/.htaccess_live
+++ b/.htaccess_live
@@ -322,9 +322,12 @@
 	# Legacy rewrite: Can't use 'master' as it confuses api.ss.org linking
 	RewriteRule ^framework/en/master(.*) http://doc.silverstripe.org/framework/en/trunk$1 [R=301,L]
 
+	# Legacy rewrite: sapphire should point to framework
+	RewriteRule ^sapphire(.*) http://doc.silverstripe.org/framework$1 [R=301,L]
+
 	# Changelogs are just kept up-to-date on trunk
-	RewriteRule ^framework/en/changelogs(.*) http://doc.silverstripe.org/framework/en/trunk/changelogs/$1 [R=301,L]
-	RewriteRule ^cms/en/changelogs(.*) http://doc.silverstripe.org/cms/en/trunk/changelogs/$1 [R=301,L]
+	RewriteRule ^framework/en/changelogs(.*) http://doc.silverstripe.org/framework/en/trunk/changelogs$1 [R=301,L]
+	RewriteRule ^cms/en/changelogs(.*) http://doc.silverstripe.org/cms/en/trunk/changelogs$1 [R=301,L]
 	
 	# Anything in sapphire/en/<version>/misc is redirected to trunk, the info in there is usually not version specific,
 	# and only updated on master (e.g. contribution and coding guidelines)


### PR DESCRIPTION
Also stops double slash when redirecting change logs.
