### PR TITLE
Block unstable versions from being indexed by search engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /src/
 .DS_Store
-.idea/
 /silverstripe-cache
 /assets
 /vendor/

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /src/
+Disallow: /en/4.0/
+Disallow: /en/3.3/


### PR DESCRIPTION
Google by default prefers to show the newest content, meaning that users are seeing 4.0 docs by default.