### PR TITLE
fix rewrite rules for old versions of documentation

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -38,140 +38,243 @@
 	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/testing/create-functional-test$ /$1/topics/testing/creating-a-functional-test [R=301,L]
 
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/?$ /$1/developer_guides [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/cache-control/?$ /$1/developer_guides/performance/caching [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/cms-alternating-button/?$ /$1/developer_guides/customising_the_admin_interface/how_tos/cms_alternating_button [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/cms-formfield-help-text/?$ /$1/developer_guides/customising_the_admin_interface/how_tos/cms_formfield_help_text [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/csv-import/?$ /$1/developer_guides/integration/csv_import [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/customize-cms-menu/?$ /$1/developer_guides/customising_the_admin_interface/how_tos/customise_cms_menu [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/customize-cms-pages-list/?$ /$1/developer_guides/customising_the_admin_interface/how_tos/customise_cms_pages_list [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/customize-cms-tree/?$ /$1/developer_guides/customising_the_admin_interface/how_tos/customise_cms_tree [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/dynamic-default-fields/?$ /$1/developer_guides/model/how_tos/dynamic_default_fields [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/extend-cms-interface/?$ /$1/developer_guides/customising_the_admin_interface/how_tos/extend_cms_interface [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/gridfield-rowaction/?$ /$1/developer_guides/forms/how_tos/create_a_gridfield_actionprovider [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/grouping-dataobjectsets/?$ /$1/developer_guides/model/how_tos/grouping_dataobject_sets [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/navigation-menu/?$ /$1/developer_guides/templates/how_tos/navigation_menus [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/pagination/?$ /$1/developer_guides/templates/how_tos/pagination [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/howto/simple-contact-form/?$ /$1/developer_guides/forms/how_tos/simple_contact_form [R=301,L]
 
 	RewriteRule ^en/installation/?$ /en/getting_started/installation [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/common-problems/?$ /$1/getting_started/installation/common_problems [R=301,L]
 	#
 	RewriteCond %{REQUEST_URI} !en/getting_started/installation/composer
 	RewriteRule ^(.*)/installation/composer/?$ /$1/getting_started/composer [R=301,L]
 	RewriteRule ^en/getting_started/installation/composer/?$ /en/getting_started/composer [R=301,L]
 	#
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/from-source/?$ /$1/getting_started/installation [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/lighttpd/?$ /$1/getting_started/installation/how_to/configure_lighttpd [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/mac-osx/?$ /$1/getting_started/installation/mac_osx [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/nginx/?$ /$1/getting_started/installation/how_to/configure_nginx [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/nginx-hhvm/?$ /$1/getting_started/installation/how_to/setup_nginx_and_hhvm [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/server-requirements/?$ /$1/getting_started/server_requirements [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/upgrading/?$ /$1/upgrading [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/webserver$ /$1/getting_started/installation [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/windows-manual-iis/?$ /$1/getting_started/installation/windows [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/windows-manual-iis-6/?$ /$1/getting_started/installation/other_installation_options/windows_iis6 [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/windows-manual-iis-7/?$ /$1/getting_started/installation/other_installation_options/windows_iis7 [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/windows-pi/?$ /$1/getting_started/installation/other_installation_options/windows_platform_installer [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/installation/windows-wamp/?$ /$1/getting_started/installation/windows [R=301,L]
 	
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/coding-conventions/?$ /$1/getting_started/coding_conventions [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/contributing/?$ /$1/contributing [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/contributing/code/?$ /$1/contributing/code [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/contributing/documentation/?$ /$1/contributing/documentation [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/contributing/issues/?$ /$1/contributing/issues_and_bugs [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/contributing/translation/?$ /$1/contributing/translations [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/contributing/translation-process/?$ /$1/contributing/translation-process [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/misc/release-process/?$ /$1/contributing/release_process [R=301,L]
 	#
 	RewriteCond %{REQUEST_URI} !en/2.4/topics/reference/requirements
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/?$ /$1/developer_guides [R=301,L]
 	RewriteRule ^en/2.4/topics/reference/requirements/?$ /en/2.4/reference/requirements [R=301,L]
 	#	
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/aspects/?$ /$1/developer_guides/extending/aspects [R=301,L]
 	#	
 	RewriteCond %{REQUEST_URI} !en/developer_guides/customising_the_admin_interface/reference/cms-architecture
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/cms-architecture/?$ /$1/developer_guides/customising_the_admin_interface/cms_architecture [R=301,L]
 	RewriteRule ^en/developer_guides/customising_the_admin_interface/reference/cms-architecture/?$ /en/developer_guides/customising_the_admin_interface/cms_architecture [R=301,L]
 	#	
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/grid-field/?$ /$1/developer_guides/forms/field_types/gridfield [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/database-structure/?$ /$1/developer_guides/model [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/dataextension/?$ /$1/developer_guides/model/extending_dataobjects [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/dataobject/?$ /$1/developer_guides/model [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/datefield/?$ /$1/developer_guides/forms/field_types/datefield [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/director/?$ /$1/developer_guides/execution_pipeline/director [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/execution-pipeline/?$ /$1/developer_guides/execution_pipeline [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/flushable/?$ /$1/developer_guides/execution_pipeline/flushable [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/form-field-types/?$ /$1/developer_guides/forms/fields/common_subclasses [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/image/?$ /$1/developer_guides/files/image [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/injector/?$ /$1/developer_guides/extending/injector [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/layout/?$ /$1/developer_guides/customising_the_admin_interface/cms_layout [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/member/?$ /$1/developer_guides/security/member [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/modeladmin/?$ /$1/developer_guides/customising_the_admin_interface/modeladmin [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/partial-caching/?$ /$1/developer_guides/performance/partial_caching [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/permission/?$ /$1/developer_guides/security/permissions [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/preview/?$ /$1/developer_guides/customising_the_admin_interface/preview [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/restfulservice/?$ /$1/developer_guides/integration/restfulservice [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/rssfeed/?$ /$1/developer_guides/integration/rssfeed [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/searchcontext/?$ /$1/developer_guides/search/searchcontext [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/shortcodes/?$ /$1/developer_guides/extending/shortcodes [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/siteconfig/?$ /$1/developer_guides/configuration/siteconfig [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/sitetree/?$ /$1/developer_guides/model/data_model_and_orm [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/templates/?$ /$1/developer_guides/templates [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/templates-format-syntax/?$ /$1/developer_guides/templates/syntax [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/typography/?$ /$1/developer_guides/customising_the_admin_interface/typography [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/uploadfield/?$ /$1/developer_guides/forms/fields [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/urlvariabletools/?$ /$1/developer_guides/debugging/url_variable_tools [R=301,L]
 
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)sqlquery/?$ /$1/sql_query [R=301,L]
 
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/?$ /$1/developer_guides [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/access-control/?$ /$1/developer_guides/security/access_control [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/authentication/?$ /$1/developer_guides/security/authentication [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/caching/?$ /$1/developer_guides/performance/caching [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/commandline/?$ /$1/developer_guides/cli [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/configuration/?$ /$1/developer_guides/configuration [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/controller/?$ /$1/developer_guides/controllers [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/css/?$ /$1/developer_guides/templates [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/data-types/?$ /$1/developer_guides/model/data_types_and_casting [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/datamodel/?$ /$1/developer_guides/model [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/debugging/?$ /$1/developer_guides/debugging [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/directory-structure/?$ /$1/getting_started/directory_structure [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/email/?$ /$1/developer_guides/email [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/error-handling/?$ /$1/developer_guides/debugging/error_handling [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/forms/?$ /$1/developer_guides/forms [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/environment-management/?$ /$1/getting_started/environment_management [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/files/?$ /$1/developer_guides/files [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/i18n/?$ /$1/developer_guides/i18n [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/javascript/?$ /$1/developer_guides/customising_the_admin_interface/javascript_development [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/module-development/?$ /$1/developer_guides/extending/how_tos/publish_a_module [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/modules/?$ /$1/developer_guides/extending/modules [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/page-type-templates/?$ /$1/developer_guides/templates/template_inheritance [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/page-types/?$ /$1/developer_guides/model/data_model_and_orm [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/rich-text-editing/?$ /$1/developer_guides/forms/field_types/htmleditorfield [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/search/?$ /$1/developer_guides/search [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/security/?$ /$1/developer_guides/security [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/testing/?$ /$1/developer_guides/testing [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/theme-development/?$ /$1/developer_guides/templates/themes [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/versioning/?$ /$1/developer_guides/model/versioning [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/topics/widgets/?$ https://github.com/silverstripe/silverstripe-widgets [R=301,L]
 	#
 	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/1-building-a-basic-site/?$ /$1/tutorials/building_a_basic_site [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/1-building-a-basic-site/?$ /$1/tutorials/building-a-basic-site [R=301,L]
 	#
 	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/2-extending-a-basic-site/?$ /$1/tutorials/extending_a_basic_site [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/2-extending-a-basic-site/?$ /$1/tutorials/extending-a-basic-site [R=301,L]
 	#
 	RewriteRule ^(.*)/tutorials/3-forms/?$ /$1/tutorials/forms [R=301,L]
 	# 
 	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/4-site-search/?$ /$1/tutorials/site_search [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/4-site-search/?$ /$1/tutorials/site-search [R=301,L]
 	#
 	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/5-dataobject-relationship-management/?$ /$1/tutorials/dataobject_relationship_management [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/tutorials/5-dataobject-relationship-management/?$ /$1/tutorials/dataobject-relationship-management [R=301,L]
 	#
 
@@ -200,8 +303,11 @@
 	RewriteRule ^member/?$ /en/developer_guides/security/member [R=301,L]
 	RewriteRule ^typography/?$ /en/developer_guides/customising_the_admin_interface/typography [R=301,L]
 	RewriteRule ^modules:auth_ext_drivers/?$ https://github.com/mattclegg/silverstripe-doc-restructuring/blob/master/output/modules/auth_ext_drivers.md [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)/reference/grid-field/?$ /$1/developer_guides/forms/field_types/gridfield [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)reference/cms-architecture/?$ /$1/cms_architecture [R=301,L]
+	RewriteCond %{REQUEST_URI} !(3.0|2.4)
 	RewriteRule ^(.*)fields/common_subclasses/?$ /$1/field_types/common_subclasses [R=301,L]
 	RewriteRule ^tabset/?$ /en/developer_guides/forms/tabbed_forms [R=301,L]
 	RewriteRule ^en/trunk/developer_guides/extending/extensions/?$ /en/developer_guides/extending/extensions [R=301,L]


### PR DESCRIPTION
fix rewrite rules to stop redirecting to new url scheme on 2.4 and 3.0 versions of documentation