### PR TITLE
Auto-redirect /contributing to current master docs (fixes #121)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -41,6 +41,10 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteCond %{REQUEST_URI} ^/?framework/en/
 	RewriteRule ^framework/en/(.*)$ /en/$1 [R=301,NC,QSA,L]
 
+	# Docs in /contributing are version agnostic, and should always point to latest
+	RewriteCond %{REQUEST_URI} !(4.0)
+	RewriteRule ^(.*)/(.*)/contributing/?(.*)?$ /$1/4.0/contributing/$3 [R=301,L]
+
 	# DokuWiki rewrite rules: Need to happen before other rules in order to redirect /doku.php?id=<pagename>
 	# to /pagename, which can then be matched by the legacy rewrite rules further down
 	RewriteCond %{QUERY_STRING}          ^(\bid\b=([^&]*)&?(.*)?)


### PR DESCRIPTION
See https://github.com/silverstripe/doc.silverstripe.org/issues/121 for context.

Pull request for updated core release instructions at https://github.com/silverstripe/silverstripe-framework/pull/5607.

Pull request for clarifying docs versions: https://github.com/silverstripe/silverstripe-framework/pull/5608

It's a bit hacky to hardcode the version there, I've tried using [RewriteRule env vars](http://httpd.apache.org/docs/2.4/rewrite/flags.html#flag_e), and they [substitute in RewriteRule](http://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewriterule), but don't in [RewriteCond](http://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewritecond). The proper way to solve this would be to use `master` in the URL, rather than the pre-release alias of `4.0`. If we fix that, we can remove the hardcoding - I don't think it blocks this PR though.

This is my failed approach at making it a variable:

```
RewriteRule ^ - [E=MASTER_VERSION:4.0]
RewriteCond %{REQUEST_URI} !(%{ENV:MASTER_VERSION}) # causes infinite redirects
RewriteRule ^(.*)/(.*)/contributing/?(.*)?$ /$1/%{ENV:MASTER_VERSION}/contributing/$3 [R=301,L]
```