### PR TITLE
FIX en/results action not being redirected

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -52,7 +52,7 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteRule ^en/3\.[5-9]/(.*)?$ /en/3/$1 [R=301,L]
 
 	# Redirect old index links to the current version
-	RewriteRule ^en/all\/?$ /en/3/all [R=301,L]
+	RewriteRule ^en/(all|results)\/?$ /en/3/$1 [R=301,L]
 
 	# DokuWiki rewrite rules: Need to happen before other rules in order to redirect /doku.php?id=<pagename>
 	# to /pagename, which can then be matched by the legacy rewrite rules further down


### PR DESCRIPTION
The Search form submits to "en/results", which doesn't have a handler in DocumentationViewer::handleAction(), so it returns the 404 from DocumentationViewer line 302.

This fix should re-direct _/en/results/_ to _/en/3/results/_  which should show the correct results based on the 'Versions' url parameter.

Fixes #163 