### PR TITLE
Update docsviewer to 2.0.0-rc1 to fix canonical URLs and default lang redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,9 +32,6 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteCond %{HTTP_HOST} ^(docs?.silverstripe.com|doc.silverstripe.org|beta.docs.silverstripe.org)$ [NC]
 	RewriteRule ^(.*)$ https://docs.silverstripe.org/$1 [L,R=301]
 
-	# Home page redirect
-	RewriteRule ^(/)?$ /en/4/ [R=302,NC,QSA,L]
-
 	# Legacy rewrite from sapphire/ to framework/ namespace
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_URI} !^framework/main\.php

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"require": {
 		"ext-gd": "*",
 		"ext-mbstring": "*",
-		"silverstripe/docsviewer": "^2.0@beta",
+		"silverstripe/docsviewer": "^2.0@rc",
 		"silverstripe/framework": "^3.2",
 		"silverstripe/toolbar": "^4.2",
 		"silverstripe/dynamodb": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6c7b612751c05e732df53cfa1d4aae0",
+    "content-hash": "3e089a4d1755a301b0b42f28b0825fba",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -637,16 +637,16 @@
         },
         {
             "name": "silverstripe/docsviewer",
-            "version": "2.0.0-beta8",
+            "version": "2.0.0-rc1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-docsviewer.git",
-                "reference": "83594bdf7785d4fc1bb87b5357a832a7bf1fb16d"
+                "reference": "fccde14751b81d19d4723cf92826d483a7555864"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-docsviewer/zipball/83594bdf7785d4fc1bb87b5357a832a7bf1fb16d",
-                "reference": "83594bdf7785d4fc1bb87b5357a832a7bf1fb16d",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-docsviewer/zipball/fccde14751b81d19d4723cf92826d483a7555864",
+                "reference": "fccde14751b81d19d4723cf92826d483a7555864",
                 "shasum": ""
             },
             "require": {
@@ -675,7 +675,7 @@
                 "documentation",
                 "silverstripe"
             ],
-            "time": "2017-08-30T01:57:52+00:00"
+            "time": "2017-11-13T01:08:23+00:00"
         },
         {
             "name": "silverstripe/dynamodb",
@@ -1378,7 +1378,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "silverstripe/docsviewer": 10,
+        "silverstripe/docsviewer": 5,
         "phpunit/phpunit": 0
     },
     "prefer-stable": true,


### PR DESCRIPTION
This pull request:

* Updates docsviewer from beta to rc1, which pulls in a fix for canonical redirects
* Will now redirect `/en` to `/en/4` as it's the first "Stable" version in the YAML configuration, instead of `/en/3` (last)
* Removes the manual root URL redirect for the homepage from htaccess, since it's now covered by the above