### PR TITLE
FIX: Remove canonical links to try and fix Swiftype indexing.

### DIFF
--- a/themes/docs/templates/Includes/DocumentationHead.ss
+++ b/themes/docs/templates/Includes/DocumentationHead.ss
@@ -6,9 +6,11 @@
 
 	<% include DocumentationFavicons %>
 
+	<%-- disabled for Swiftype indexing
 	<% if $CanonicalUrl %>
 		<link rel="canonical" href="$CanonicalUrl" />
 	<% end_if %>
+	--%>
 	<link rel="stylesheet" href="$ThemeDir/css/ionicons.min.css" />
 	<link rel="stylesheet" href="$ThemeDir/css/styles.css" />
 	<script type="text/javascript" src="//use.typekit.net/emt4dhq.js"></script>


### PR DESCRIPTION
Swiftype support have suggested that our canonical links might be
preventing correct indexing. As a trial of this, this patch disables
the canonical links.