### PR TITLE
Update search template and move outside header to fix being behind overlay

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"ext-mbstring": "*",
 		"silverstripe/docsviewer": "^2.0",
 		"silverstripe/framework": "~3.6",
-		"silverstripe/toolbar": "^4.2",
+		"silverstripe/toolbar": "dev-feature/55276-swiftype-search",
 		"silverstripe/dynamodb": "^3",
 		"mandrew/silverstripe-quickfeedback": "^0.2",
 		"silverstripe/raygun": "^1.1"
@@ -15,10 +15,10 @@
 		"phpunit/phpunit": "~3.7@stable"
 	},
 	"repositories": [
-        {
-            "type": "vcs",
-            "url": "git://github.com/silverstripe/silverstripe-globaltoolbar.git"
-        }
+		{
+			"type": "vcs",
+			"url": "https://github.com/lexakami/silverstripe-globaltoolbar"
+		}
 	],
 	"config": {
 		"process-timeout": 600

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"ext-mbstring": "*",
 		"silverstripe/docsviewer": "^2.0",
 		"silverstripe/framework": "~3.6",
-		"silverstripe/toolbar": "dev-feature/55276-swiftype-search",
+		"silverstripe/toolbar": "~4.2.3",
 		"silverstripe/dynamodb": "^3",
 		"mandrew/silverstripe-quickfeedback": "^0.2",
 		"silverstripe/raygun": "^1.1"
@@ -17,7 +17,7 @@
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "https://github.com/lexakami/silverstripe-globaltoolbar"
+			"url": "https://github.com/silverstripe/silverstripe-globaltoolbar.git"
 		}
 	],
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66e3760a1d7af03c0407bd5abb301dd3",
+    "content-hash": "584b20c5ae4aa35473bb51416f1500a2",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1184,16 +1184,16 @@
         },
         {
             "name": "silverstripe/toolbar",
-            "version": "dev-feature/55276-swiftype-search",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/lexakami/silverstripe-globaltoolbar.git",
-                "reference": "f669e9148d40d3dd32f52bd3ce74148074bec6c7"
+                "url": "https://github.com/silverstripe/silverstripe-globaltoolbar.git",
+                "reference": "999a1c2587f13b5953498f6453d74c8469c24b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lexakami/silverstripe-globaltoolbar/zipball/f669e9148d40d3dd32f52bd3ce74148074bec6c7",
-                "reference": "f669e9148d40d3dd32f52bd3ce74148074bec6c7",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-globaltoolbar/zipball/999a1c2587f13b5953498f6453d74c8469c24b64",
+                "reference": "999a1c2587f13b5953498f6453d74c8469c24b64",
                 "shasum": ""
             },
             "require": {
@@ -1221,9 +1221,10 @@
                 "silverstripe"
             ],
             "support": {
-                "source": "https://github.com/lexakami/silverstripe-globaltoolbar/tree/feature/55276-swiftype-search"
+                "source": "https://github.com/silverstripe/silverstripe-globaltoolbar/tree/4.2.3",
+                "issues": "https://github.com/silverstripe/silverstripe-globaltoolbar/issues"
             },
-            "time": "2019-08-08T04:59:31+00:00"
+            "time": "2019-08-12T23:19:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1754,7 +1755,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "silverstripe/toolbar": 20,
         "phpunit/phpunit": 0
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bebddbda993b76e7ce5d76d5963b1764",
+    "content-hash": "66e3760a1d7af03c0407bd5abb301dd3",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1184,16 +1184,16 @@
         },
         {
             "name": "silverstripe/toolbar",
-            "version": "4.2.2",
+            "version": "dev-feature/55276-swiftype-search",
             "source": {
                 "type": "git",
-                "url": "https://github.com/silverstripe/silverstripe-globaltoolbar.git",
-                "reference": "1b0ea930e122e21f44fbb3b0e7c62ea7d47a06c3"
+                "url": "https://github.com/lexakami/silverstripe-globaltoolbar.git",
+                "reference": "f669e9148d40d3dd32f52bd3ce74148074bec6c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-globaltoolbar/zipball/1b0ea930e122e21f44fbb3b0e7c62ea7d47a06c3",
-                "reference": "1b0ea930e122e21f44fbb3b0e7c62ea7d47a06c3",
+                "url": "https://api.github.com/repos/lexakami/silverstripe-globaltoolbar/zipball/f669e9148d40d3dd32f52bd3ce74148074bec6c7",
+                "reference": "f669e9148d40d3dd32f52bd3ce74148074bec6c7",
                 "shasum": ""
             },
             "require": {
@@ -1221,10 +1221,9 @@
                 "silverstripe"
             ],
             "support": {
-                "source": "https://github.com/silverstripe/silverstripe-globaltoolbar/tree/4.2",
-                "issues": "https://github.com/silverstripe/silverstripe-globaltoolbar/issues"
+                "source": "https://github.com/lexakami/silverstripe-globaltoolbar/tree/feature/55276-swiftype-search"
             },
-            "time": "2019-07-08T23:12:15+00:00"
+            "time": "2019-08-08T04:59:31+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1755,6 +1754,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "silverstripe/toolbar": 20,
         "phpunit/phpunit": 0
     },
     "prefer-stable": true,

--- a/themes/docs/templates/Includes/DocumentationHead.ss
+++ b/themes/docs/templates/Includes/DocumentationHead.ss
@@ -28,8 +28,8 @@
 		<div id="navWrapper">
 			<div class="nav-mobile">
 				$GlobalNav('doc')
-				<% include SearchBox %>
 			</div>
 		</div>
 	</div>
 </header>
+<% include SearchModal %>


### PR DESCRIPTION
Reliant on https://github.com/silverstripe/silverstripe-globaltoolbar/pull/49 and https://github.com/silverstripeltd/silverstripe.org/pull/143

This PR needs to be updated with the updated toolbar when https://github.com/silverstripe/silverstripe-globaltoolbar/pull/49 is merged