### PR TITLE
Whitelist main content for swiftype

### DIFF
--- a/themes/docs/templates/Layout/DocumentationViewer_DocumentationPage.ss
+++ b/themes/docs/templates/Layout/DocumentationViewer_DocumentationPage.ss
@@ -1,11 +1,11 @@
-<div id="documentation-page" class="box">
+<div id="documentation-page" class="box" data-swiftype-index="true">
 	<% if VersionWarning %>
 		<% include DocumentationVersion_warning Version=$Entity.Version %>
 	<% end_if %>
 
 	<% include DocumentationTableContents %>
 
-		
+
 	$Content.RAW
 
 	<div class="quickfeedback clearfix">$QuickFeedbackForm</div>


### PR DESCRIPTION
Prevents unneeded header/sidebar/footer text etc from being indexed for each page