### PR TITLE
FIX v3 docs should track `3` branch

### DIFF
--- a/sources-docs.js
+++ b/sources-docs.js
@@ -13,7 +13,7 @@ module.exports = [
         options: {
           name: `docs--3`,
           remote: `https://github.com/silverstripe/silverstripe-framework.git`,
-          branch: `3.7`,
+          branch: `3`,
           patterns: `docs/en/**`
         }
       },    


### PR DESCRIPTION
Previously tracking the 3.7 branch - not showing the most up to date documentation