### PR TITLE
FIX Ensure changelogs are sorted correctly.

### DIFF
--- a/src/utils/sortFiles.ts
+++ b/src/utils/sortFiles.ts
@@ -1,10 +1,40 @@
 import { SilverstripeDocument } from "../types";
+import path from 'path';
+
+/**
+ * Validates whether a given string looks like a semantic versioning number
+ */
+function isVersionNumber(value: string): boolean {
+    return /^\d+\.\d+\.\d+(-(alpha|beta|rc)\d*)?$/.test(value);
+}
 
 const sortFiles = (a: SilverstripeDocument, b: SilverstripeDocument): number => {
     if (a.isIndex !== b.isIndex) {
         //return a.isIndex ? -1 : 1;
     }
-    return a.fileAbsolutePath > b.fileAbsolutePath ? 1 : -1;
+
+    let compA = a.fileAbsolutePath;
+    let compB = b.fileAbsolutePath;
+    const compareOptions = {
+        numeric: false,
+        sensitivity: 'case',
+    };
+
+    // Only apply special comparison logic for files in the same directory
+    if (path.dirname(a.fileAbsolutePath) === path.dirname(b.fileAbsolutePath)) {
+        // Compare numbers and version numbers numerically
+        if (
+            (!isNaN(a.fileTitle) && !isNaN(b.fileTitle))
+            || (isVersionNumber(a.fileTitle) && isVersionNumber(a.fileTitle))
+        ) {
+            // compare numerically
+            compA = a.fileTitle;
+            compB = b.fileTitle;
+            compareOptions.numeric = true;
+        }
+    }
+
+    return compA.localeCompare(compB, 'en', compareOptions);
 };
 
 export default sortFiles;


### PR DESCRIPTION
The use of `localeCompare` also allows macrons to be used in filenames without adversely affecting the sorting.

## Parent issue
- #237 