### PR TITLE
FIX Ensure mailto links work as expected.

### DIFF
--- a/src/utils/rewriteLink.ts
+++ b/src/utils/rewriteLink.ts
@@ -41,6 +41,15 @@ const rewriteLink = (
     const currentNode = getCurrentNode();
     const version = getCurrentVersion();
 
+    // mailto links
+    if (href.startsWith('mailto:')) {
+        return createElement(
+            'a',
+            { href },
+            domToReact(children, parseOptions)
+        );
+    }
+
     // hash links
     if (href.startsWith('#')) {
         return createElement(


### PR DESCRIPTION
While an email address formatted without a link (e.g. `some-email@example.com` as opposed to `[some-email@example.com](mailto:some-email@example.com)`) should be formatted correctly as a mailto link in the final page, there is some documentation already using the explicit link style, and even if we changed that now it won't stop someone adding another one in the future - so it behoves us to fix this.

## Parent Issue
- #235 