### PR TITLE
FIX Don't break headings when they include sub-elements.

### DIFF
--- a/src/utils/parseHTML.ts
+++ b/src/utils/parseHTML.ts
@@ -29,7 +29,7 @@ const parseHTML = (html: string): ReactElement | ReactElement[] | string => {
             const domChildren = children || [];
             if (name && attribs) {
                 if (name === 'a') {
-                    return rewriteLink(attribs, domChildren, parseOptions);
+                    return rewriteLink(attribs, domChildren, parseOptions, domNode);
                 }
                 if (name === 'table') {
                     return rewriteTable(domChildren, parseOptions);

--- a/src/utils/rewriteLink.ts
+++ b/src/utils/rewriteLink.ts
@@ -8,6 +8,7 @@ import { SilverstripeDocument } from '../types';
 
 interface LinkAttributes {
     href?: string;
+    class?: string;
 };
 
 
@@ -31,7 +32,8 @@ const relativeLink = (currentNode: SilverstripeDocument, href: string): string =
 const rewriteLink = (
     attribs: LinkAttributes,
     children: DomElement[],
-    parseOptions: HTMLReactParserOptions
+    parseOptions: HTMLReactParserOptions,
+    domNode: DomElement
 ): ReactElement|false => {
     const { href } = attribs;
     if (!href) {
@@ -43,6 +45,11 @@ const rewriteLink = (
 
     // hash links
     if (href.startsWith('#')) {
+        // Just let normal parsing occur for heading links
+        if (attribs.class === 'anchor') {
+            return domToReact(domNode);
+        }
+        // rewrite all other hashlinks
         return createElement(
             Link,
             { 


### PR DESCRIPTION
\<code\> tags added to headings via backticks are the main culprit, but ultimately if any elements other than text were being added to the heading, only part of the heading would display, and any custom ID for the heading anchor link would not be used.

## Parent issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/215