### PR TITLE
NEW Add CMS 5 sources to user and dev docs (plus some other related changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ Silverstripe CMS 4.x is stored in
 
 The userhelp documentation is stored in the [silverstripe/silverstripe-userhelp-content repo](https://github.com/silverstripe/silverstripe-userhelp-content/).
 
+## What to update when creating a new pre-release major branch, making a stable major release, or making a major EOL
+
+When **creating a new major branch for a pre-release major version**
+
+- Make sure you've added a new major branch to both `silverstripe/developer-docs` and `silverstripe/silverstripe-userhelp-content`
+  - You probably need to add new major branches for various modules as defined in `sources-user.js` as well
+- Add the new major to `sources-docs.js` and `sources-user.js`
+- Add the new major to the version select in `src/components/Header.tsx`
+- Add the major to the `PRE_RELEASE` array in the `getVersionMessage` function in `src/utils/nodes.ts`
+
+For **new stable releases**, you will need to do the following
+
+- Remove the major from the `PRE_RELEASE` array in the `getVersionMessage` function in `src/utils/nodes.ts`
+- Update the `getDefaultVersion` function's return value to the new stable major in `src/utils/nodes.ts`
+- Update redirects in `netlify.toml`
+
+When a **major goes EOL**, add the major to the `EOL` array in the `getVersionMessage` function in `src/utils/nodes.ts`
+
 ## Installation
 
 To set up a local instance of [doc.silverstripe.org](https://github.com/silverstripe/doc.silverstripe.org):

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -14,7 +14,7 @@ class IconExtractor {
         const matches = content.match(/icon(Brand)?: ([a-zA-Z0-9_-]+)/);
         if (matches) {
           const isBrand = typeof matches[1] !== 'undefined';
-          selectors.push(isBrand ? `fab` : `fas`);
+          selectors.push(isBrand ? 'fab' : 'fas');
           selectors.push(`fa-${matches[2]}`);
         }
         return selectors;
@@ -29,6 +29,12 @@ const whitelist = [
     // Syntax highlighting
     'pre',
     'code',
+
+    // Icon classes used in nodes.ts
+    'far',
+    'fa-calendar',
+    'fa-check-circle',
+    'fa-times-circle',
 ];
 
 const whitelistPatterns = [

--- a/sources-docs.js
+++ b/sources-docs.js
@@ -1,20 +1,29 @@
 module.exports = [
-    {
-        resolve: `gatsby-source-git`,
-        options: {
-          name: `docs--4`,
-          remote: `https://github.com/silverstripe/developer-docs.git`,
-          branch: `4.11`,
-          patterns: `en/**`
-        }
-      },    
-      {
-        resolve: `gatsby-source-git`,
-        options: {
-          name: `docs--3`,
-          remote: `https://github.com/silverstripe/developer-docs.git`,
-          branch: `3`,
-          patterns: `en/**`
-        }
-      },    
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `docs--5`,
+      remote: `https://github.com/silverstripe/developer-docs.git`,
+      branch: `5`,
+      patterns: `en/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `docs--4`,
+      remote: `https://github.com/silverstripe/developer-docs.git`,
+      branch: `4.11`,
+      patterns: `en/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `docs--3`,
+      remote: `https://github.com/silverstripe/developer-docs.git`,
+      branch: `3`,
+      patterns: `en/**`
+    }
+  },
 ];

--- a/sources-user.js
+++ b/sources-user.js
@@ -1,4 +1,177 @@
 module.exports = [
+  // v5
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+        name: `user--5`,
+        remote: `https://github.com/silverstripe/silverstripe-userhelp-content.git`,
+        branch: `5`,
+        patterns: `docs/en/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/setting_up_advancedworkflow`,
+      remote: `https://github.com/symbiote/silverstripe-advancedworkflow`,
+      branch: `6`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/online_databases_and_registries`,
+      remote: `https://github.com/silverstripe/silverstripe-registry`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/content_review`,
+      remote: `https://github.com/silverstripe/silverstripe-contentreview`,
+      branch: `5`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/blogs`,
+      remote: `https://github.com/silverstripe/silverstripe-blog`,
+      branch: `4`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/forms`,
+      remote: `https://github.com/silverstripe/silverstripe-userforms`,
+      branch: `6`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/working_with_multiple_websites`,
+      remote: `https://github.com/silverstripe/silverstripe-subsites`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/taxonomies`,
+      remote: `https://github.com/silverstripe/silverstripe-taxonomy`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/iframe`,
+      remote: `https://github.com/silverstripe/silverstripe-iframe`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/site_wide_rss_feeds`,
+      remote: `https://github.com/silverstripe/silverstripe-versionfeed`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/content_blocks`,
+      remote: `https://github.com/dnadesign/silverstripe-elemental`,
+      branch: `5`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/modules_report`,
+      remote: `https://github.com/bringyourownideas/silverstripe-maintenance`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/share_draft_content`,
+      remote: `https://github.com/silverstripe/silverstripe-sharedraftcontent`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/document_converter`,
+      remote: `https://github.com/silverstripe/silverstripe-documentconverter`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/ckan_registry`,
+      remote: `https://github.com/silverstripe/silverstripe-ckan-registry`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/multi-factor_authentication`,
+      remote: `https://github.com/silverstripe/silverstripe-mfa`,
+      branch: `5`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--managing_your_website/reports/security_report`,
+      remote: `https://github.com/silverstripe/silverstripe-securityreport`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`,
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--managing_your_website/reports/sitewide_content_report`,
+      remote: `https://github.com/silverstripe/silverstripe-sitewidecontent-report`,
+      branch: `4`,
+      patterns: `docs/en/userguide/**`,
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--5--optional_features/managing_devices`,
+      remote: `https://github.com/silverstripe/silverstripe-session-manager`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+
   // v4
   {
     resolve: `gatsby-source-git`,

--- a/sources-user.js
+++ b/sources-user.js
@@ -1,416 +1,311 @@
 module.exports = [
-  /******* main content *********/
   // v4
   {
-      resolve: `gatsby-source-git`,
-      options: {
-          name: `user--4`,
-          remote: `https://github.com/silverstripe/silverstripe-userhelp-content.git`,
-          branch: `4`,            
-          patterns: `docs/en/**`
-      }
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4`,
+      remote: `https://github.com/silverstripe/silverstripe-userhelp-content.git`,
+      branch: `4`,
+      patterns: `docs/en/**`
+    }
   },
-  // v3    
   {
-      resolve: `gatsby-source-git`,
-      options: {
-          name: `user--3`,
-          remote: `https://github.com/silverstripe/silverstripe-userhelp-content.git`,
-          branch: `3`,
-          patterns: `docs/en/**`
-      }
-  },      
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/setting_up_advancedworkflow`,
+      remote: `https://github.com/symbiote/silverstripe-advancedworkflow`,
+      branch: `5`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/online_databases_and_registries`,
+      remote: `https://github.com/silverstripe/silverstripe-registry`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/content_review`,
+      remote: `https://github.com/silverstripe/silverstripe-contentreview`,
+      branch: `4`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/blogs`,
+      remote: `https://github.com/silverstripe/silverstripe-blog`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/forms`,
+      remote: `https://github.com/silverstripe/silverstripe-userforms`,
+      branch: `5`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/working_with_multiple_websites`,
+      remote: `https://github.com/silverstripe/silverstripe-subsites`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/taxonomies`,
+      remote: `https://github.com/silverstripe/silverstripe-taxonomy`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/iframe`,
+      remote: `https://github.com/silverstripe/silverstripe-iframe`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/site_wide_rss_feeds`,
+      remote: `https://github.com/silverstripe/silverstripe-versionfeed`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/content_blocks`,
+      remote: `https://github.com/dnadesign/silverstripe-elemental`,
+      branch: `4`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/modules_report`,
+      remote: `https://github.com/bringyourownideas/silverstripe-maintenance`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/share_draft_content`,
+      remote: `https://github.com/silverstripe/silverstripe-sharedraftcontent`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/document_converter`,
+      remote: `https://github.com/silverstripe/silverstripe-documentconverter`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/ckan_registry`,
+      remote: `https://github.com/silverstripe/silverstripe-ckan-registry`,
+      branch: `1`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/multi-factor_authentication`,
+      remote: `https://github.com/silverstripe/silverstripe-mfa`,
+      branch: `4`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--managing_your_website/reports/security_report`,
+      remote: `https://github.com/silverstripe/silverstripe-securityreport`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`,
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--managing_your_website/reports/sitewide_content_report`,
+      remote: `https://github.com/silverstripe/silverstripe-sitewidecontent-report`,
+      branch: `3`,
+      patterns: `docs/en/userguide/**`,
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--4--optional_features/managing_devices`,
+      remote: `https://github.com/silverstripe/silverstripe-session-manager`,
+      branch: `1`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
 
-  
   // v3
   {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/versionedfiles`,
-        remote: `https://github.com/symbiote/silverstripe-versionedfiles`,
-        branch: `master`,        
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-  
-  // v3
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3`,
+      remote: `https://github.com/silverstripe/silverstripe-userhelp-content.git`,
+      branch: `3`,
+      patterns: `docs/en/**`
+    }
+  },
   {
-      // Running a fork. Switch remote back once merged.
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/setting_up_advancedworkflow`,
-        remote: `https://github.com/symbiote/silverstripe-advancedworkflow`,
-        branch: `4`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/setting_up_advancedworkflow`,
-        remote: `https://github.com/symbiote/silverstripe-advancedworkflow`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* registry ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/online_databases_and_registries`,
-        remote: `https://github.com/silverstripe/silverstripe-registry`,
-        branch: `1.0`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/online_databases_and_registries`,
-        remote: `https://github.com/silverstripe/silverstripe-registry`,
-        branch: `master`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* forum ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/forums`,
-        remote: `https://github.com/silverstripe-archive/silverstripe-forum`,
-        branch: `0.8`,        
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* contentreview ********/
-
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/content_review`,
-        remote: `https://github.com/silverstripe/silverstripe-contentreview`,
-        branch: `master`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* blog ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/blogs`,
-        remote: `https://github.com/silverstripe/silverstripe-blog`,
-        branch: `2`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/blogs`,
-        remote: `https://github.com/silverstripe/silverstripe-blog`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* userforms ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/forms`,
-        remote: `https://github.com/silverstripe/silverstripe-userforms`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* translatable ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/working_with_translations`,
-        remote: `https://github.com/silverstripe/silverstripe-translatable`,
-        branch: `2.1`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* subsites ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/working_with_multiple_websites`,
-        remote: `https://github.com/silverstripe/silverstripe-subsites`,
-        branch: `1.1`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/working_with_multiple_websites`,
-        remote: `https://github.com/silverstripe/silverstripe-subsites`,
-        branch: `1.1`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* secureassets ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/securing_files`,
-        remote: `https://github.com/silverstripe/silverstripe-secureassets`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* taxonomy ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/taxonomies`,
-        remote: `https://github.com/silverstripe/silverstripe-taxonomy`,          
-        branch: `1`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/taxonomies`,
-        remote: `https://github.com/silverstripe/silverstripe-taxonomy`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* iframe ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/iframe`,
-        remote: `https://github.com/silverstripe/silverstripe-iframe`,
-        branch: `1.0`,          
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/iframe`,
-        remote: `https://github.com/silverstripe/silverstripe-iframe`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* versionfeed ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/site_wide_rss_feeds`,
-        remote: `https://github.com/silverstripe/silverstripe-versionfeed`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/site_wide_rss_feeds`,
-        remote: `https://github.com/silverstripe/silverstripe-versionfeed`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* dms ********/
-
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--optional_features/document_management_system`,
-        remote: `https://github.com/silverstripe/silverstripe-dms`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* elemental ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/content_blocks`,        
-        remote: `https://github.com/dnadesign/silverstripe-elemental`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/modules_report`,
-        remote: `https://github.com/bringyourownideas/silverstripe-maintenance`,        
-        branch: `1`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* sharedraftcontent ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/share_draft_content`,
-        remote: `https://github.com/silverstripe/silverstripe-sharedraftcontent`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* documentconverter ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/document_converter`,
-        remote: `https://github.com/silverstripe/silverstripe-documentconverter`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* ckan-registry ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/ckan_registry`,
-        remote: `https://github.com/silverstripe/silverstripe-ckan-registry`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******* mfa ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/multi-factor_authentication`,
-        remote: `https://github.com/silverstripe/silverstripe-mfa`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
-
-    /******** securityreport ********/
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--managing_your_website/reports/security_report`,
-        remote: `https://github.com/silverstripe/silverstripe-securityreport`,          
-        branch: `master`,
-        patterns: `docs/en/userguide/**`,
-      }        
-    },
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--managing_your_website/reports/security_report`,
-        remote: `https://github.com/silverstripe/silverstripe-securityreport`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`,
-      }        
-    },
-
-    /******** sitewide-content-report ********/
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--managing_your_website/reports/sitewide_content_report`,
-        remote: `https://github.com/silverstripe/silverstripe-sitewidecontent-report`,
-        branch: `master`,
-        patterns: `docs/en/userguide/**`,
-      }        
-    },
-    // v3
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--3--managing_your_website/reports/sitewide_content_report`,
-        remote: `https://github.com/silverstripe/silverstripe-sitewidecontent-report`,
-        branch: `2.0`,
-        patterns: `docs/en/userguide/**`,
-      }        
-    },
-
-    /******* session-manager ********/
-
-    // v4
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `user--4--optional_features/managing_devices`,
-        remote: `https://github.com/silverstripe/silverstripe-session-manager`,
-        branch: `1`,
-        patterns: `docs/en/userguide/**`        
-      }
-    },
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/versionedfiles`,
+      remote: `https://github.com/symbiote/silverstripe-versionedfiles`,
+      branch: `master`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/setting_up_advancedworkflow`,
+      remote: `https://github.com/symbiote/silverstripe-advancedworkflow`,
+      branch: `4`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/online_databases_and_registries`,
+      remote: `https://github.com/silverstripe/silverstripe-registry`,
+      branch: `1.0`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/forums`,
+      remote: `https://github.com/silverstripe-archive/silverstripe-forum`,
+      branch: `0.8`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/blogs`,
+      remote: `https://github.com/silverstripe/silverstripe-blog`,
+      branch: `2`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/working_with_translations`,
+      remote: `https://github.com/silverstripe/silverstripe-translatable`,
+      branch: `2.1`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/working_with_multiple_websites`,
+      remote: `https://github.com/silverstripe/silverstripe-subsites`,
+      branch: `1.1`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/securing_files`,
+      remote: `https://github.com/silverstripe/silverstripe-secureassets`,
+      branch: `master`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/taxonomies`,
+      remote: `https://github.com/silverstripe/silverstripe-taxonomy`,
+      branch: `1`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/iframe`,
+      remote: `https://github.com/silverstripe/silverstripe-iframe`,
+      branch: `1.0`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/site_wide_rss_feeds`,
+      remote: `https://github.com/silverstripe/silverstripe-versionfeed`,
+      branch: `master`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--optional_features/document_management_system`,
+      remote: `https://github.com/silverstripe/silverstripe-dms`,
+      branch: `master`,
+      patterns: `docs/en/userguide/**`
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--managing_your_website/reports/security_report`,
+      remote: `https://github.com/silverstripe/silverstripe-securityreport`,
+      branch: `master`,
+      patterns: `docs/en/userguide/**`,
+    }
+  },
+  {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `user--3--managing_your_website/reports/sitewide_content_report`,
+      remote: `https://github.com/silverstripe/silverstripe-sitewidecontent-report`,
+      branch: `2.0`,
+      patterns: `docs/en/userguide/**`,
+    }
+  },
 ];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -61,7 +61,8 @@ const Header: StatelessComponent<HeaderProps> = ({ handleSidebarToggle }): React
               </div>
               <ul className="social-list list-inline d-flex flex-grow-1 flex-lg-grow-0 align-items-center justify-content-lg-center justify-content-end justify-content-lg-end">
                 <li className="list-inline-item version-select">
-                  <select id="version-select" value={getCurrentVersion() || '4'} onChange={handleNavigate}>
+                  <select id="version-select" value={getCurrentVersion()} onChange={handleNavigate}>
+                      <option value='5'>V5</option>
                       <option value='4'>V4</option>
                       <option value='3'>V3</option>
                   </select>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,7 +11,7 @@ interface LayoutProps {
   }
 }
 const Layout: StatelessComponent<LayoutProps> = ({ children, pageContext: { slug } }) => {
-  const { setCurrentPath, getVersionPath, getCurrentVersion, getCurrentNode } = useHierarchy();
+  const { setCurrentPath, getVersionPath, getCurrentVersion, getCurrentNode, getDefaultVersion } = useHierarchy();
   const [isToggled, setSidebarOpen] = useState(false);
   const handleNavigate = () => setSidebarOpen(false);
   
@@ -21,12 +21,12 @@ const Layout: StatelessComponent<LayoutProps> = ({ children, pageContext: { slug
 
   return (
     <>
-    {currentNode && ver !== '4' && (
+    {currentNode && ver !== getDefaultVersion() && (
       <Helmet
         link={[
           {
             rel: 'canonical',
-            href: getVersionPath(currentNode, '4'),
+            href: getVersionPath(currentNode, getDefaultVersion()),
           }
         ]}
        />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,13 +11,14 @@ interface LayoutProps {
   }
 }
 const Layout: StatelessComponent<LayoutProps> = ({ children, pageContext: { slug } }) => {
-  const { setCurrentPath, getVersionPath, getCurrentVersion, getCurrentNode, getDefaultVersion } = useHierarchy();
+  const { setCurrentPath, getVersionPath, getCurrentVersion, getCurrentNode, getDefaultVersion, getVersionMessage } = useHierarchy();
   const [isToggled, setSidebarOpen] = useState(false);
   const handleNavigate = () => setSidebarOpen(false);
   
   setCurrentPath(slug);
   const ver = getCurrentVersion();
   const currentNode = getCurrentNode();
+  const versionMessage = getVersionMessage();
 
   return (
     <>
@@ -37,7 +38,10 @@ const Layout: StatelessComponent<LayoutProps> = ({ children, pageContext: { slug
       <div className="docs-content">
         <div className="container">
           <article role="main" className="docs-article">
+            <>
+            {versionMessage}
             {children}
+            </>
           </article>
         </div> 
       </div>

--- a/src/components/NodeProvider.tsx
+++ b/src/components/NodeProvider.tsx
@@ -14,6 +14,7 @@ import {
     initialise,
     getVersionPath,
     setCurrentPath,
+    getDefaultVersion,
 } from '../utils/nodes';
 
 const NodeProvider: StatelessComponent<{}> = ({ children, pageContext: { slug } }): ReactElement => {
@@ -59,6 +60,7 @@ const NodeProvider: StatelessComponent<{}> = ({ children, pageContext: { slug } 
             getSiblings,
             getVersionPath,
             setCurrentPath,
+            getDefaultVersion,
         }}>
           {children}
       </NodeContext.Provider>

--- a/src/components/NodeProvider.tsx
+++ b/src/components/NodeProvider.tsx
@@ -15,6 +15,7 @@ import {
     getVersionPath,
     setCurrentPath,
     getDefaultVersion,
+    getVersionMessage,
 } from '../utils/nodes';
 
 const NodeProvider: StatelessComponent<{}> = ({ children, pageContext: { slug } }): ReactElement => {
@@ -61,6 +62,7 @@ const NodeProvider: StatelessComponent<{}> = ({ children, pageContext: { slug } 
             getVersionPath,
             setCurrentPath,
             getDefaultVersion,
+            getVersionMessage,
         }}>
           {children}
       </NodeContext.Provider>

--- a/src/hooks/useHierarchy.ts
+++ b/src/hooks/useHierarchy.ts
@@ -12,8 +12,9 @@ interface NodeFunctions {
     getHomePage(): SilverstripeDocument|null;
     getNavChildren(node: SilverstripeDocument): SilverstripeDocument[];
     getCurrentVersion(): string;
-    getVersionPath(currentNode: SilverstripeDocument, version: number): string;
+    getVersionPath(currentNode: SilverstripeDocument, version: number|string): string;
     setCurrentPath(slug: string): undefined;
+    getDefaultVersion(): string;
 };
 
 const useHierarchy = (): NodeFunctions => {

--- a/src/hooks/useHierarchy.ts
+++ b/src/hooks/useHierarchy.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, ReactElement } from 'react';
 import NodeContext from '../contexts/NodeContext';
 import { SilverstripeDocument } from '../types';
 
@@ -15,6 +15,7 @@ interface NodeFunctions {
     getVersionPath(currentNode: SilverstripeDocument, version: number|string): string;
     setCurrentPath(slug: string): undefined;
     getDefaultVersion(): string;
+    getVersionMessage():  ReactElement | ReactElement[] | string | null;
 };
 
 const useHierarchy = (): NodeFunctions => {

--- a/src/theme/assets/scss/bootstrap/scss/_nav.scss
+++ b/src/theme/assets/scss/bootstrap/scss/_nav.scss
@@ -14,9 +14,10 @@
 .nav-link {
   display: block;
   padding: $nav-link-padding-y $nav-link-padding-x;
+  text-decoration: none;
 
   @include hover-focus {
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   // Disabled state lightens text

--- a/src/theme/assets/scss/theme.scss
+++ b/src/theme/assets/scss/theme.scss
@@ -29,9 +29,13 @@ $wordpress-color: #028cb0;
 $single-col-max: 800px;
 
 $theme-success-color: #5cb377;
+$theme-success-color-dark: #39794D;
 $theme-warning-color: #EEBF41;
+$theme-warning-color-dark: #9E6100;
 $theme-info-color: #5b99ea;
+$theme-info-color-dark: #1c6fdc;
 $theme-danger-color: #d26d69;
+$theme-danger-color-dark: #b73c37;
 
 
 

--- a/src/theme/assets/scss/theme/_base.scss
+++ b/src/theme/assets/scss/theme/_base.scss
@@ -13,6 +13,10 @@ h1, h2, h3, h4, h5, h6 {
 	font-family: 'Poppins', sans-serif;
 	color: $theme-text-color-primary;
 	font-weight: 600;
+
+	code[class*="language-"] {
+		font-size: 0.8em;
+	}
 }
 
 code {
@@ -59,16 +63,27 @@ code {
 	border-bottom-color: darken($theme-bg-light, 5%);
 }
 
-a.theme-link {
-	color: $theme-text-color-primary;
+a {
 	text-decoration: underline;
-    -webkit-text-decoration-color: rgba($theme-text-color-primary,0.3);
-    text-decoration-color: rgba($theme-text-color-primary,0.3);
-    &:hover {
-	    color: $theme-color-primary;
-	    -webkit-text-decoration-color: rgba($theme-color-primary,0.8);
-	        text-decoration-color: rgba($theme-color-primary,0.8);
-    }
+
+	&:hover {
+		text-decoration: none;
+	}
+
+	&.theme-link {
+		color: $theme-text-color-primary;
+		-webkit-text-decoration-color: rgba($theme-text-color-primary,0.3);
+		text-decoration-color: rgba($theme-text-color-primary,0.3);
+		&:hover {
+			color: $theme-color-primary;
+			-webkit-text-decoration-color: rgba($theme-color-primary,0.8);
+				text-decoration-color: rgba($theme-color-primary,0.8);
+		}
+	}
+
+	&.btn {
+		text-decoration: none;
+	}
 }
 
 .btn {

--- a/src/theme/assets/scss/theme/_docs.scss
+++ b/src/theme/assets/scss/theme/_docs.scss
@@ -384,6 +384,60 @@
 	}
 }
 
+.callout-block--version {
+	border-left-width: 6px;
+	padding-top: 1rem;
+	padding-bottom: 1rem;
+	
+	.callout-version-title {
+		display: flex;
+		font-size: 1rem;
+		font-weight: $font-weight-bold;
+		color: lighten($theme-text-color-primary, 15%);
+
+		.callout-version-stability {
+			display: flex;
+			align-items: center;
+			margin-left: auto;
+			font-size: 1.125rem;
+		}
+
+		.callout-version-stability-text {
+			text-transform: uppercase;
+			font-size: 0.875rem;
+			margin-left: 10px;
+		}
+	}
+
+	.callout-version-content {
+		padding-top: 10px;
+	}
+
+	&.callout-block-success {
+		.callout-version-stability {
+			color: darken($theme-success-color, 15%);
+		}
+	}
+
+	&.callout-block-info {
+		.callout-version-stability {
+			color: darken($theme-info-color, 15%);
+		}
+	}
+
+	&.callout-block-warning {
+		.callout-version-stability {
+			color: darken($theme-warning-color, 15%);
+		}
+	}
+
+	&.callout-block-danger {
+		.callout-version-stability {
+			color: darken($theme-danger-color, 15%);
+		}
+	}
+}
+
 
 .cta-section {
 	.container {

--- a/src/theme/assets/scss/theme/_docs.scss
+++ b/src/theme/assets/scss/theme/_docs.scss
@@ -172,11 +172,6 @@
 	.section-title {
 		font-size: 1rem;
 		margin-bottom: 1rem;
-		a {
-			&:hover {
-				text-decoration: none;
-			}
-		}
 	}
 	.section-items {
 		font-size: 0.875rem;
@@ -207,7 +202,6 @@
 			color: $theme-color-primary;
 			&:before {
 				background-color: $theme-color-primary;
-				
 			}
 			.theme-icon-holder {
 				color: #fff;
@@ -267,7 +261,6 @@
 				margin-bottom: 0;
 			}
 		}
-		
 	}
 
 	.anchor {
@@ -275,18 +268,6 @@
 		margin-left: 1rem;
 		opacity: 0;
 		transition: opacity .2s;
-
-		/* Force anchor link to offset header */
-		margin-top: -90px;
-		padding-top: 90px;
-
-		&:focus {
-			opacity: 1;
-
-			/* Outline behaves incorrectly due to offset, use underline instead */
-			outline: none;
-			text-decoration: underline;
-		}
 	}
 	:hover > .anchor {
 		opacity: 1;

--- a/src/theme/assets/scss/theme/_docs.scss
+++ b/src/theme/assets/scss/theme/_docs.scss
@@ -327,40 +327,40 @@
 		border-color: $theme-info-color;
 		background: lighten($theme-info-color, 35%);
 		.callout-title {
-			color: darken($theme-info-color, 15%);
+			color: $theme-info-color-dark;
 		}
 		a {
-			color: darken($theme-info-color, 15%);
+			color: $theme-info-color-dark;
 		}
 	}
 	&.callout-block-success {
 		border-color: $theme-success-color;
 		background: lighten($theme-success-color, 40%);
 		.callout-title {
-			color: darken($theme-success-color, 15%);
+			color: $theme-success-color-dark;
 		}
 		a {
-			color: darken($theme-success-color, 15%);
+			color: $theme-success-color-dark;
 		}
 	}
 	&.callout-block-warning {
 		border-color: $theme-warning-color;
 		background: lighten($theme-warning-color, 35%);
 		.callout-title {
-			color: darken($theme-warning-color, 15%);
+			color: $theme-warning-color-dark;
 		}
 		a {
-			color: darken($theme-warning-color, 15%);
+			color: $theme-warning-color-dark;
 		}
 	}
 	&.callout-block-danger {
 		border-color: $theme-danger-color;
 		background: lighten($theme-danger-color, 35%);
 		.callout-title {
-			color: darken($theme-danger-color, 15%);
+			color: $theme-danger-color-dark;
 		}
 		a {
-			color: darken($theme-danger-color, 15%);
+			color: $theme-danger-color-dark;
 		}
 	}
 }
@@ -396,25 +396,25 @@
 
 	&.callout-block-success {
 		.callout-version-stability {
-			color: darken($theme-success-color, 15%);
+			color: $theme-success-color-dark;
 		}
 	}
 
 	&.callout-block-info {
 		.callout-version-stability {
-			color: darken($theme-info-color, 15%);
+			color: $theme-info-color-dark;
 		}
 	}
 
 	&.callout-block-warning {
 		.callout-version-stability {
-			color: darken($theme-warning-color, 15%);
+			color: $theme-warning-color-dark;
 		}
 	}
 
 	&.callout-block-danger {
 		.callout-version-stability {
-			color: darken($theme-danger-color, 15%);
+			color: $theme-danger-color-dark;
 		}
 	}
 }

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -140,9 +140,14 @@ const getHomePage = (): SilverstripeDocument | null => {
 };
 
 /**
+ * Get the default version
+ */
+const getDefaultVersion = (): string => '4';
+
+/**
  * Get the selected version
  */
-const getCurrentVersion = (): string => __currentVersion || '4';
+const getCurrentVersion = (): string => __currentVersion || getDefaultVersion();
 
 
 /**
@@ -178,5 +183,6 @@ export {
   getNavChildren,
   getCurrentVersion,
   getVersionPath,
-  setCurrentPath
+  setCurrentPath,
+  getDefaultVersion,
 };

--- a/src/utils/rewriteAPILink.ts
+++ b/src/utils/rewriteAPILink.ts
@@ -1,9 +1,11 @@
+import { getCurrentVersion } from './nodes';
+
 /**
  * If an href is preceded with api:, rewrite it to the api.silverstripe.org site
  * @param link 
  */
 const rewriteAPILink = (link: string): string => {
-    const version = 4;
+    const version = getCurrentVersion();
     const match = link.match(/api\:(.*)/);
     if (!match) {
         console.error(`Unable to resolve api link ${link}!`);

--- a/src/utils/rewriteHeader.ts
+++ b/src/utils/rewriteHeader.ts
@@ -65,6 +65,13 @@ const rewriteHeaders = (domNode: DomElement): ReactElement | false => {
 
         domNode.children?.push(anchor);
 
+        if (domNode.name === 'h1') {
+            if (!domNode.attribs) {
+                domNode.attribs = {};
+            }
+            domNode.attribs['aria-details'] = 'version-callout';
+        }
+
         return domToReact([domNode]);
 
     }


### PR DESCRIPTION
**DO NOT SQUASH**
There are several related but distinct changes being made here:

- Adding CMS5 sources for dev and user docs
- Fixing CMS4 branches for user docs sources
- Fixing rewrite API URLs to use the correct CMS version
- Add version banners (including pre-release and EOL warnings) to the top of docs
- Update README with instructions for how to make these updates in the future
- Improve accessibility of links
  - Include an underline by default 
  - Remove underline on hover
  - This is reversed for nav items, which are contextually obviously links.
- Make font size of code blocks inside headings relative to the heading font size
- Increase contrast on callout block links for accessibility

## NOTES
- This PR assumes several branches will be created on various branches for CMS5 - see the list in the parent issue, or check the CMS5 branches listed in `sources-user.js`
- **DO NOT SQUASH**

## Parent issue
- https://github.com/silverstripe/developer-docs/issues/44