### PR TITLE
MNT Update v4 docs branch to 4.12

### DIFF
--- a/sources-docs.js
+++ b/sources-docs.js
@@ -13,7 +13,7 @@ module.exports = [
     options: {
       name: `docs--4`,
       remote: `https://github.com/silverstripe/developer-docs.git`,
-      branch: `4.11`,
+      branch: `4.12`,
       patterns: `en/**`
     }
   },


### PR DESCRIPTION
Updates the branch for CMS 4 docs to 4.12 (required for beta changelog to be displayed)

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/606