### PR TITLE
MNT Get docs from the 5.1 branch

### DIFF
--- a/sources-docs.js
+++ b/sources-docs.js
@@ -4,7 +4,7 @@ module.exports = [
     options: {
       name: 'docs--5',
       remote: 'https://github.com/silverstripe/developer-docs.git',
-      branch: '5.0',
+      branch: '5.1',
       patterns: 'en/**'
     }
   },


### PR DESCRIPTION
Updates the branch for CMS 5 docs to 5.1 (required for beta changelog to be displayed)

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/803