### PR TITLE
FIX Render callout blocks correctly

### DIFF
--- a/src/utils/cleanCalloutTags.ts
+++ b/src/utils/cleanCalloutTags.ts
@@ -5,9 +5,16 @@
  * @returns
  */
 const cleanCalloutTags = (html: string): string => {
+    // Replace callout <p> tags with a <callout> tag so we can swap it out with the right react component
+    html = html.replace(
+        /<p>\s*\[(hint|warning|info|alert|notice|note)\](.*?)\[\/\1\]\s*<\/p>/gs,
+        (_, type, content) => `<callout type="${type}">${content}</callout>`
+    );
+    // Replace any <p> and </p> tags inside callout tags with <br>, since the above operation may have
+    // inadvertantly broken some <p> tags.
     return html.replace(
-        /(?:<p>\s*)((?:\[(hint|warning|info|alert|notice|note)\]).*?(?:\[\/(hint|warning|info|alert|notice|note)\]))(?:\s*<\/p>)/gs,
-        (_, callout) => callout
+        /<callout type="[a-z]*">.*?<\/callout>/gs,
+        (callout) => callout.replace(/(<p>|<\/p>)/g, '<br>')
     );
 };
 

--- a/src/utils/parseCalloutTags.ts
+++ b/src/utils/parseCalloutTags.ts
@@ -5,19 +5,8 @@ import CalloutBlock from '../components/CalloutBlock';
  * Turn [hint] and other callouts into a proper React component.
  * @param data
  */
-const parseCalloutTags = (data: any): ReactElement|false => {
-    let matches;
-
-    matches = data.match(/\[(hint|warning|info|alert|notice|note)\](.*?)\[\/(?:hint|warning|info|alert|notice|note)\]/s);
-
-    if (matches) {
-        const type = matches[1];
-        const content = matches[2];
-
-        return createElement(CalloutBlock, { type, content });
-    }
-
-    return false;
+const parseCalloutTags = (type: string, content: any): ReactElement|false => {
+    return createElement(CalloutBlock, { type, content });
 };
 
 export default parseCalloutTags;

--- a/src/utils/parseHTML.ts
+++ b/src/utils/parseHTML.ts
@@ -1,4 +1,4 @@
-import parse, { DomElement } from 'html-react-parser';
+import parse, { DomElement, domToReact } from 'html-react-parser';
 import cleanChildrenTags from './cleanChildrenTags';
 import cleanWhitespace from './cleanWhitespace';
 import cleanApiTags from './cleanApiTags';
@@ -12,7 +12,7 @@ import cleanHeaders from './cleanHeaders';
 import parseCalloutTags from './parseCalloutTags';
 
 /**
- * Replace all the [CHILDREN] with proper React components.
+ * Replace all the [CHILDREN] and callout tags with proper React components.
  * @param html 
  * @return ReactElement | ReactElement[] | string
  */
@@ -38,13 +38,15 @@ const parseHTML = (html: string): ReactElement | ReactElement[] | string => {
                 if (name.match(/^h[0-9]$/)) {
                     return rewriteHeader(domNode);
                 }
+                if (name === 'callout') {
+                    return parseCalloutTags(domNode.attribs.type, domToReact(domNode.children));
+                }
             }
             if (domNode.data && domNode.parent?.name !== 'code') {
                 const { data } = domNode;
                 if (data.match(/\[CHILDREN.*?\]/)) {
                     return parseChildrenOf(data);
                 }
-                return parseCalloutTags(data);
             }
 
             return false;


### PR DESCRIPTION
- `<p>` tags surrounding callout blocks are swapped out for `<callout>` tags, which are used to identify the element that needs to be replaced.
- If there are paragraphs _inside_ the callout block, the basic regex replace we did will have broken them, so we need to swap them out for `<br>` tags. This renders the same as if they were `<p>` tags because they'll come in pairs.
  - e.g. `<p>[hint]some text</p><p>more text[/hint]</p>` would have become `<callout type="hint">some text</p><p>more text</callout>` which would break the page. So we turn it into `<callout type="hint">some text<br><br>more text</callout>`
- Also protects us from accidentally not closing callout blocks - previously `[hint]some text[hint][info]more text[/info]` would have turned into a single hint callout, because we didn't close the hint block correctly. This has resulted in plenty of errors in the past. Now it will simply not try to render the hint block, so the page won't be _as_ badly broken.

## Issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/276