### PR TITLE
FIX Resolve final callout block issues

### DIFF
--- a/src/theme/assets/scss/theme/_docs.scss
+++ b/src/theme/assets/scss/theme/_docs.scss
@@ -284,7 +284,8 @@
 		font-size: 1rem;
 	}
 
-	.content p:last-of-type {
+	// Don't add unnecessary space at the end of a callout block
+	.content > :last-child {
 		margin-bottom: 0;
 	}
 	

--- a/src/utils/parseCalloutTags.ts
+++ b/src/utils/parseCalloutTags.ts
@@ -1,12 +1,16 @@
 import { ReactElement, createElement } from 'react';
+import { DomElement, HTMLReactParserOptions, domToReact } from "html-react-parser";
 import CalloutBlock from '../components/CalloutBlock';
 
 /**
  * Turn [hint] and other callouts into a proper React component.
  * @param data
  */
-const parseCalloutTags = (type: string, content: any): ReactElement|false => {
-    return createElement(CalloutBlock, { type, content });
+const parseCalloutTags = (type: string, domChildren: DomElement[], parseOptions: HTMLReactParserOptions): ReactElement|false => {
+    return createElement(CalloutBlock, {
+        type,
+        content: domToReact(domChildren, parseOptions),
+    });
 };
 
 export default parseCalloutTags;

--- a/src/utils/parseHTML.ts
+++ b/src/utils/parseHTML.ts
@@ -55,7 +55,7 @@ const parseHTML = (html: string): ReactElement | ReactElement[] | string => {
                         }
                         // Remove the type marker and render the component
                         firstTextNode.data = firstTextNode.data.replace(calloutTypeRegex, '');
-                        return parseCalloutTags(matches[1], domToReact(children));
+                        return parseCalloutTags(matches[1], children, parseOptions);
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes two final callout block issues:
1. A paragraph might not be the last item in the callout block - we should remove the bottom margin from the last element regardless of what that element is.
E.g. see the list in a callout block in https://docs.silverstripe.org/en/5/developer_guides/templates/syntax/#variables
2. Links in callout blocks weren't being parsed, and therefore weren't rendering correctly. E.g. see "Formatting, Modifying and Casting Variables" in https://docs.silverstripe.org/en/5/developer_guides/templates/syntax/

## Issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/282