### PR TITLE
ENH Add linkfield docs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -48,7 +48,7 @@ exports.onCreateNode = async ({ node, getNode, getNodesByType, actions, createNo
     }
     return;
   }   
-  const basePath = category === 'user' ? `docs/en/userguide` : `en`;
+  const basePath = category === 'user' ? 'docs/en/userguide' : (thirdparty ? 'docs/en' : 'en');
   const filePath = createFilePath({
     node,
     getNode,

--- a/sources-docs.js
+++ b/sources-docs.js
@@ -11,6 +11,15 @@ module.exports = [
   {
     resolve: 'gatsby-source-git',
     options: {
+      name: 'docs--5--optional_features/linkfield',
+      remote: 'https://github.com/silverstripe/silverstripe-linkfield.git',
+      branch: '4.0',
+      patterns: 'docs/en/**'
+    }
+  },
+  {
+    resolve: 'gatsby-source-git',
+    options: {
       name: 'docs--4',
       remote: 'https://github.com/silverstripe/developer-docs.git',
       branch: '4.13',

--- a/src/utils/rewriteLink.ts
+++ b/src/utils/rewriteLink.ts
@@ -96,7 +96,33 @@ const rewriteLink = (
         )
     }
 
-    // absolute links
+    // absolute links to docs (unversioned)
+    if (href.match(/^https?:\/\/docs.silverstripe.org\/en\/[a-zA-Z]/)) {
+        return createElement(
+            Link,
+            {
+                to: path.join('/', 'en', version, href.replace(/^https?:\/\/docs.silverstripe.org\/en/, '')),
+                className: 'gatsby-link'
+            },
+            domToReact(children, parseOptions)
+        );
+    }
+
+    // absolute links to docs (versioned)
+    const hrefMatch = href.match(/^https?:\/\/docs.silverstripe.org\/en\/([0-9]+)/);
+    if (hrefMatch) {
+        const hrefVersion = hrefMatch[1];
+        return createElement(
+            Link,
+            {
+                to: path.join('/', 'en', hrefVersion, href.replace(/^https?:\/\/docs.silverstripe.org\/en\/([0-9]+)/, '')),
+                className: 'gatsby-link'
+            },
+            domToReact(children, parseOptions)
+        );
+    }
+
+    // absolute links to anywhere else
     if (href.match(/^https?/)) {
         return createElement(
             'a',


### PR DESCRIPTION
Adds linkfield docs to the "optional features" section

Note the preview won't show it, because it's not looking at the creative-commoners PR nor does it have the change from the dev docs PR to add the section link.

## Issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/27