### PR TITLE
ENH Add graphql as an optional module

### DIFF
--- a/sources-docs.js
+++ b/sources-docs.js
@@ -46,6 +46,15 @@ module.exports = [
     }
   },
   {
+    resolve: `gatsby-source-git`,
+    options: {
+      name: `docs--6--optional_features/graphql`,
+      remote: `https://github.com/silverstripe/silverstripe-graphql.git`,
+      branch: `6`,
+      patterns: 'docs/en/!(userguide)/**'
+    }
+  },
+  {
     resolve: 'gatsby-source-git',
     options: {
       name: 'docs--6--optional_features/mfa/authenticators/totp-authenticator',


### PR DESCRIPTION
Issue https://github.com/silverstripe/doc.silverstripe.org/issues/304

Needs https://github.com/silverstripe/silverstripe-graphql/pull/604 for the nav title to become 'GraphQL' instead of 'en'