### PR TITLE
FIX Update API links URL for new hosting

### DIFF
--- a/src/utils/rewriteAPILink.ts
+++ b/src/utils/rewriteAPILink.ts
@@ -12,7 +12,7 @@ const rewriteAPILink = (link: string): string => {
         return link;
     }
 
-    return `https://api.silverstripe.org/search/lookup?q=${match[1]}&version=${version}`;
+    return `https://api.silverstripe.org/search.html?q=${match[1]}&version=${version}`;
 };
 
 export default rewriteAPILink;


### PR DESCRIPTION
As per https://github.com/silverstripe/api.silverstripe.org/pull/127 once we've updated hosting to GitHub Pages the search URL will change from `https://api.silverstripe.org/search/lookup` to `https://api.silverstripe.org/search.html`

> [!IMPORTANT]
> **_DO NOT MERGE_** until hosting has swapped over

## Issue
- https://github.com/silverstripe/api.silverstripe.org/issues/122