### PR TITLE
FIX remove smooth-scroll

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,12 +5,7 @@ require('./src/theme/assets/fontawesome/css/all.css');
 const React = require('react');
 const Layout = require('./src/components/Layout').default;
 const NodeProvider = require('./src/components/NodeProvider').default;
-const smoothScroll = require('smooth-scroll');
 
-
-if (typeof window !== "undefined") {
-    smoothScroll('a[href*="#"]')
-  }  
 
 /**
  * Ensures the chrome doesn't rerender every page load, which makes the sidebar reset its scroll.
@@ -47,7 +42,7 @@ const anchorScroll = location => {
     setTimeout(() => {
       const item = document.querySelector(`${location.hash}`).offsetTop;
       const mainNavHeight = document.querySelector(`header`).offsetHeight;
-      window.scrollTo({top: item - mainNavHeight, left: 0, behavior: 'smooth'});
+      window.scrollTo({top: item - mainNavHeight, left: 0, behavior: 'instant'});
     }, 0);
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-spring": "^8.0.27",
     "resize-observer-polyfill": "^1.5.1",
     "sharp": "^0.30.5",
-    "smooth-scroll": "^16.1.0",
     "styled-components": "^4.4.1",
     "unist-util-select": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14107,11 +14107,6 @@ slugify@^1.4.4:
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.5.tgz#c8f5c072bf2135b80703589b39a3d41451fbe8c8"
   integrity sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==
 
-smooth-scroll@^16.1.0:
-  version "16.1.3"
-  resolved "https://registry.yarnpkg.com/smooth-scroll/-/smooth-scroll-16.1.3.tgz#c5b68194b4186173f9f61065103ae4e26ce36885"
-  integrity sha512-ca9U+neJS/cbdScTBuUTCZvUWNF2EuMCk7oAx3ImdeRK5FPm+xRo9XsVHIkeEVkn7MBRx+ufVEhyveM4ZhaTGA==
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
## Description

As per discussion in Slack - smooth scroll is frustrating and slow, so this removes it.

## Manual testing steps

For a great example, click on "full commits list" on https://docs.silverstripe.org/en/5/changelogs/5.0.0. Check that this no longer takes ~15 seconds to scroll.

## Issues

https://github.com/silverstripe/doc.silverstripe.org/issues/319

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
