### PR TITLE
css smooth scroll & scroll-margin-top

### DIFF
--- a/src/theme/assets/scss/ss-docs.scss
+++ b/src/theme/assets/scss/ss-docs.scss
@@ -1,5 +1,8 @@
 body {
     font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+    @media (prefers-reduced-motion: no-preference) {
+        scroll-behavior: smooth;
+    }
 }
 .docs-wrapper {
     &.sidebar-visible {
@@ -267,4 +270,15 @@ code[class*="language-"], pre[class*="language-"] {
 
 .api-link {
     text-decoration: underline;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    > a[id] {
+		scroll-margin-top: 80px;
+	}
 }


### PR DESCRIPTION
## Description
re-add smooth scroll but per CSS see #318 & https://silverstripe-users.slack.com/archives/C0QSDASKT/p1733868383012199 In addition to smooth-scroll, scroll-margin-top is added to anchors.

## Manual testing steps
If it just works than fine, otherwise close. Couldn't test - docker build failed. First it needed node 18 than it said ```ERROR UNKNOWN
There was a problem loading the local build command. Gatsby may not be installed in your site's "node_modules" directory. Perhaps you need to run "npm install"? You might need to delete your "package-lock.json" as well.``` ...nothing worked :hear_no_evil:

## Issues
CSS smooth-scroll isn't slow & jerky

## Pull request checklist
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
