### PR TITLE
ENH Update versions to reflect CMS 6 is stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ When **creating a new major branch for a pre-release major version**
 
 - Make sure you've added a new major branch to both `silverstripe/developer-docs` and `silverstripe/silverstripe-userhelp-content`
 - Add the new major to `sources-docs.js` and `sources-user.js`
-- Add new major branches for various modules as defined in `sources-docs.js` and `sources-user.js` as well
+- Add the new major branches for various modules as defined in `sources-docs.js` and `sources-user.js` as well
 - Add the new major to the version select in `src/components/Header.tsx`
-- Add the major to the `PRE_RELEASE` array in the `getVersionMessage` function in `src/utils/nodes.ts`
+- Add the new major to the `PRE_RELEASE` array in the `getVersionMessage` function in `src/utils/nodes.ts`
 - Add the new major version to the [algolia crawler script](https://crawler.algolia.com/admin/crawlers/3d14ccdd-f9ae-4957-bc0a-5b21b4c29af3/configuration/edit)
 
 For **new stable releases**, you will need to do the following
@@ -36,7 +36,8 @@ For **new stable releases**, you will need to do the following
 - Remove the major from the `PRE_RELEASE` array in the `getVersionMessage` function in `src/utils/nodes.ts`
 - Update the `getDefaultVersion` function's return value to the new stable major in `src/utils/nodes.ts`
 - Update redirects in `netlify.toml`
-- Update `index.tsx` to navigate to the new stable major
+- Update `src/pages/index.tsx` to navigate to the new stable major
+- Add the new major to `redirects` in `gatsby-node.js`
 
 When a **major goes EOL**, add the major to the `EOL` array in the `getVersionMessage` function in `src/utils/nodes.ts`
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -144,11 +144,12 @@ exports.createPages = async ({ actions, graphql, getNodesByType }) => {
 
     console.log(`Creating legacy redirects...`);
     const redirects = new Map();
+    const v6docs = getNodesByType('SilverstripeDocument').filter(n => n.slug.match(/^\/en\/6\//));
     const v5docs = getNodesByType('SilverstripeDocument').filter(n => n.slug.match(/^\/en\/5\//));
     const v4docs = getNodesByType('SilverstripeDocument').filter(n => n.slug.match(/^\/en\/4\//));
     const v3docs = getNodesByType('SilverstripeDocument').filter(n => n.slug.match(/^\/en\/3\//));
     
-    [...v5docs, ...v4docs, ...v3docs].forEach(n => {
+    [...v6docs, ...v5docs, ...v4docs, ...v3docs].forEach(n => {
       const legacy = n.slug.replace(/^\/en\/[0-9]\//, '/en/');
       if (legacy === '/en/') {
         return;

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,22 +6,22 @@
 
 [[redirects]]
   from = "/"
-  to = "/en/5/"
+  to = "/en/6/"
   status = 302
 
 [[redirects]]
   from = "/en"
-  to = "/en/5/"
+  to = "/en/6/"
   status = 302
 
 [[redirects]]
   from = "/framework/en/*"
-  to = "/en/5/:splat"
+  to = "/en/6/:splat"
   status = 302
 
 [[redirects]]
   from = "/contributing"
-  to = "/en/5/contributing/"
+  to = "/en/6/contributing/"
 
 [[redirects]]
   from = "/en/4/getting_started/installation/common_problems"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { navigate } from '@reach/router'
 
 const IndexPage = () => {
     useEffect(() => {
-        navigate('/en/5/');
+        navigate('/en/6/');
     }, []);
 
     return <div />;

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -143,7 +143,7 @@ const getHomePage = (): SilverstripeDocument | null => {
 /**
  * Get the default version
  */
-const getDefaultVersion = (): string => '5';
+const getDefaultVersion = (): string => '6';
 
 /**
  * Get the selected version
@@ -156,13 +156,12 @@ const getCurrentVersion = (): string => __currentVersion || getDefaultVersion();
 const getVersionMessage = (): ReactElement | ReactElement[] | string | null => {
   const EOL = [
     '3',
-  ];
-  const PREVIOUS_RELEASE = [
     '4',
   ];
-  const PRE_RELEASE = [
-    '6',
+  const PREVIOUS_RELEASE = [
+    '5',
   ];
+  const PRE_RELEASE = [];
   const version = getCurrentVersion();
   const stablePath = getVersionPath(getCurrentNode(), getDefaultVersion());
 


### PR DESCRIPTION
Followed instructions in the readme.

CMS 6 is the new current stable
CMS 4 is EOL

## Issue

- https://github.com/silverstripe/.github/issues/407