### PR TITLE
FIX Make code in headings render the correct size

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cp .env.development .env.production
 Then, run the build.
 
 ```
-yarn build-docs
+yarn build
 yarn serve
 
 # or with docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,8 @@
 FROM node:12
 
-RUN yarn global add gatsby-cli
+# This command first finds Yarn's global directory, ensures it exists,
+# then creates a package.json file with the specific version resolution for 'tmp',
+# and finally, installs gatsby-cli.
+# These specific versions are needed as a temporary solution for running on node 12.
+RUN yarn global dir | xargs -I {} sh -c 'mkdir -p {} && echo "{\"private\": true, \"resolutions\": {\"tmp\": \"0.2.1\"}}" > {}/package.json' && \
+    yarn global add gatsby-cli@^3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-entrypoint: &entry
   - /bin/bash
   - /app/docker/entrypoint.sh

--- a/docker/run
+++ b/docker/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cd $(dirname $0) && docker-compose run -u $(id -u) --rm gatsby $@
+cd $(dirname $0) && docker compose run -u $(id -u) --rm gatsby $@

--- a/src/theme/assets/scss/theme/_base.scss
+++ b/src/theme/assets/scss/theme/_base.scss
@@ -13,11 +13,15 @@ h1, h2, h3, h4, h5, h6 {
 	font-family: 'Poppins', sans-serif;
 	color: $theme-text-color-primary;
 	font-weight: 600;
+}
 
+/*! purgecss start ignore */
+h1, h2, h3, h4, h5, h6 {
 	code[class*="language-"] {
-		font-size: 0.8em;
+		font-size: 0.9em;
 	}
 }
+/*! purgecss end ignore */
 
 code {
 	background: $theme-bg-light;


### PR DESCRIPTION
> [!IMPORTANT]
> There are intentionally 2 commits here. DO NOT SQUASH
> The first commit just makes it easier to get set up locally, since the most recent version of gatsby-cli can't be installed with node 12

The CSS for this already existed, but purgecss was ignoring it.

I initially tried getting it to stop ignoring everything for `^h[1-6]$` and their children but that _completely_ changed the way headings were styled - arguably for the better, but that isn't in scope for this issue.

**Before:**
<img width="266" height="71" alt="image" src="https://github.com/user-attachments/assets/5506fb2f-a73a-44fc-9d2f-27bb44bc3a0d" />


**After:**
<img width="266" height="71" alt="image" src="https://github.com/user-attachments/assets/bf61444e-1701-42dc-979c-f99483a8eafa" />

## Issue

- https://github.com/silverstripe/doc.silverstripe.org/issues/281
