### PR TITLE
FIX Don't rewrite links for images

### DIFF
--- a/src/utils/rewriteLink.ts
+++ b/src/utils/rewriteLink.ts
@@ -131,6 +131,15 @@ const rewriteLink = (
         );
     }
 
+    // Image links
+    if (href.match(/\.(jpg|jpeg|gif|png|webp|avif|tiff|bmp)$/i)) {
+        return createElement(
+            'a',
+            { href, target: '_blank' },
+            domToReact(children, parseOptions)
+        );
+    }
+
     // Relative to root
     if (href.startsWith('/')) {
         return createElement(


### PR DESCRIPTION
Note that while other image formats could theoretically be included in our docs, only the formats listed in
https://www.gatsbyjs.com/plugins/gatsby-remark-images/?=image#supported-formats would ever have links to them anyway.

## Issue

- https://github.com/silverstripe/doc.silverstripe.org/issues/261