### PR TITLE
ENH Ensure version selector colour matches status message

### DIFF
--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -42,6 +42,7 @@ const whitelistPatterns = [
     /^DocSearch-/,
     /^btn/,
     /^copy-button/,
+    /version-select--[a-z-]+$/,
 ];
 
 const whitelistPatternsChildren = [

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ interface HeaderProps {
 }
 
 const Header: StatelessComponent<HeaderProps> = ({ handleSidebarToggle }): ReactElement => {
-    const { getHomePage, getCurrentNode, getCurrentVersion, getVersionPath } = useHierarchy();
+    const { getHomePage, getCurrentNode, getCurrentVersion, getVersionPath, getVersionStatus } = useHierarchy();
     const home = getHomePage();
     const currentNode = getCurrentNode() || home;
     const context = useDocContext();
@@ -34,6 +34,7 @@ const Header: StatelessComponent<HeaderProps> = ({ handleSidebarToggle }): React
     const title = context === 'user' ? 'CMS Help' : 'CMS Docs';
     const gitHref = currentGitRemote && currentGitRemote.hasOwnProperty('href')
        ? currentGitRemote.href.replace(/\.git$/, '') : '';
+    const currentVersion = getCurrentVersion();
 
     return (
     <header role="banner" className="header fixed-top">	    
@@ -55,8 +56,8 @@ const Header: StatelessComponent<HeaderProps> = ({ handleSidebarToggle }): React
                 {process.env.GATSBY_DOCSEARCH_API_KEY && <SearchBox />}
               </div>
               <ul className="social-list list-inline d-flex flex-grow-1 flex-lg-grow-0 align-items-center justify-content-lg-center justify-content-end justify-content-lg-end">
-                <li className="list-inline-item version-select">
-                  <select id="version-select" value={getCurrentVersion()} onChange={handleNavigate}>
+                <li className={`list-inline-item version-select version-select--${getVersionStatus(currentVersion)}`}>
+                  <select id="version-select" value={currentVersion} onChange={handleNavigate}>
                       <option value='6'>V6</option>
                       <option value='5'>V5</option>
                       <option value='4'>V4</option>

--- a/src/components/NodeProvider.tsx
+++ b/src/components/NodeProvider.tsx
@@ -16,6 +16,7 @@ import {
     setCurrentPath,
     getDefaultVersion,
     getVersionMessage,
+    getVersionStatus,
 } from '../utils/nodes';
 
 const NodeProvider: StatelessComponent<{}> = ({ children, pageContext: { slug } }): ReactElement => {
@@ -63,6 +64,7 @@ const NodeProvider: StatelessComponent<{}> = ({ children, pageContext: { slug } 
             setCurrentPath,
             getDefaultVersion,
             getVersionMessage,
+            getVersionStatus,
         }}>
           {children}
       </NodeContext.Provider>

--- a/src/hooks/useHierarchy.ts
+++ b/src/hooks/useHierarchy.ts
@@ -16,6 +16,7 @@ interface NodeFunctions {
     setCurrentPath(slug: string): undefined;
     getDefaultVersion(): string;
     getVersionMessage():  ReactElement | ReactElement[] | string | null;
+    getVersionStatus(version: string): string;
 };
 
 const useHierarchy = (): NodeFunctions => {

--- a/src/theme/assets/scss/ss-docs.scss
+++ b/src/theme/assets/scss/ss-docs.scss
@@ -139,7 +139,6 @@ code {
                appearance: none;
                 border: 0;
                 color: $gray-800;
-                background: $theme-color-primary;
                 border-radius: 100px;
                 color: #fff;
                 padding: 0.45rem 1.25rem 0.45rem 0.75rem;
@@ -155,6 +154,18 @@ code {
                 font-size: 0.6rem;
                 opacity: 0.8;
             }
+        }
+        .version-select--current select {
+            background: $theme-success-color-dark;
+        }
+        .version-select--previous select {
+            background: $theme-info-color-dark;
+        }
+        .version-select--pre-release select {
+            background: $theme-warning-color-dark;
+        }
+        .version-select--eol select {
+            background: $theme-danger-color-dark;
         }
     }
 }

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -14,6 +14,15 @@ const siblingMap = new Map();
 const parentMap = new Map();
 const nodeMap = new Map();
 
+const EOL = [
+  '3',
+  '4',
+];
+const PREVIOUS_RELEASE = [
+  '5',
+];
+const PRE_RELEASE = [];
+
 /**
  * Hydrate these functions with the list of all nodes
  * @param nodes 
@@ -150,18 +159,27 @@ const getDefaultVersion = (): string => '6';
  */
 const getCurrentVersion = (): string => __currentVersion || getDefaultVersion();
 
+const getVersionStatus = (version: string): string => {
+  if (EOL.includes(version)) {
+    return 'eol';
+  }
+
+  if (PRE_RELEASE.includes(version)) {
+    return 'pre-release';
+  }
+
+
+  if (PREVIOUS_RELEASE.includes(version)) {
+    return 'previous';
+  }
+
+  return 'current';
+}
+
 /**
  * Get a message to display for all pages on this version's docs
  */
 const getVersionMessage = (): ReactElement | ReactElement[] | string | null => {
-  const EOL = [
-    '3',
-    '4',
-  ];
-  const PREVIOUS_RELEASE = [
-    '5',
-  ];
-  const PRE_RELEASE = [];
   const version = getCurrentVersion();
   const stablePath = getVersionPath(getCurrentNode(), getDefaultVersion());
 
@@ -241,4 +259,5 @@ export {
   setCurrentPath,
   getDefaultVersion,
   getVersionMessage,
+  getVersionStatus,
 };


### PR DESCRIPTION
> [!NOTE]
> I know the AC said "Currently supported versions remain blue" but that looked weird to me when all the others matched the banner colouring.
> This also means there's clear distinction between the most recent and the previous major release lines.

**Before:**
Always blue regardless of the status
<img width="1069" height="211" alt="existing version status styling" src="https://github.com/user-attachments/assets/5a358185-54e4-4a1b-97ee-9d65445b5e79" />

**After:**
<img width="1069" height="273" alt="EOL version status" src="https://github.com/user-attachments/assets/93d6bdb2-91be-405e-9b14-1d222b40cbde" />
<img width="1069" height="273" alt="Previous version status" src="https://github.com/user-attachments/assets/00f3b1bb-5522-40ec-8d12-d0aa20cdabcd" />
<img width="1069" height="273" alt="Stable version status" src="https://github.com/user-attachments/assets/4005c88b-9b83-4163-a001-7e00899ef776" />
<img width="1069" height="273" alt="Pre-stable version status" src="https://github.com/user-attachments/assets/baa35a93-a244-437d-b2b5-684e37997ff3" />

## Issue

- https://github.com/silverstripe/doc.silverstripe.org/issues/315
