### PR TITLE
FIX Prevent inline details and summary tags from affecting TOC

### DIFF
--- a/src/lib/toc/extract-headings.ts
+++ b/src/lib/toc/extract-headings.ts
@@ -26,8 +26,42 @@ const HEADING_REGEX = /^(#{2,3})\s+(.+?)(?:\s*\{#([^}]+)\})?\s*$/gm;
  * Helper to determine if a position in the markdown is inside a <details> block
  * Tracks all <details> opening and closing tags up to the given position
  */
+function stripCodeFromMarkdown(markdown: string): string {
+  const lines = markdown.split('\n');
+  let inFence = false;
+  let fenceMarker = '';
+
+  return lines
+    .map((line) => {
+      const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+
+      if (fenceMatch) {
+        const marker = fenceMatch[1];
+
+        if (!inFence) {
+          inFence = true;
+          fenceMarker = marker;
+          return '';
+        }
+
+        if (marker[0] === fenceMarker[0] && marker.length >= fenceMarker.length) {
+          inFence = false;
+          fenceMarker = '';
+          return '';
+        }
+      }
+
+      if (inFence) {
+        return '';
+      }
+
+      return line.replace(/`[^`]*`/g, '');
+    })
+    .join('\n');
+}
+
 function isInsideDetailsBlock(markdown: string, position: number): boolean {
-  const textBeforePosition = markdown.slice(0, position);
+  const textBeforePosition = stripCodeFromMarkdown(markdown.slice(0, position));
   let depth = 0;
 
   // Match opening <details> tags (case-insensitive, optional attributes)

--- a/tests/fixtures/release-changelog-details.md
+++ b/tests/fixtures/release-changelog-details.md
@@ -1,0 +1,26 @@
+# 6.2.0-beta1 Release Notes
+
+## Overview
+
+Highlights for this prerelease.
+
+## Included Module Versions
+
+<details>
+<summary>Click to expand module versions</summary>
+
+### Hidden Framework Changes
+
+- Internal API updates.
+
+</details>
+
+When documenting collapsible sections, use `<details>` with a `<summary>` label.
+
+## Upgrade Notes
+
+Follow these steps before upgrading.
+
+### Breaking Changes
+
+Review the updated method signatures.


### PR DESCRIPTION
Issue https://github.com/silverstripe/doc.silverstripe.org/issues/379

Cause was `<details>` / `<summary>` text inside the contents of the changelog

I tested manually by adding the 5.2.0-beta1 changelog to my local content cache and it rendered the TOC correctly